### PR TITLE
fix: use CircleCI image with Docker version: "19.03.13"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,11 @@ jobs:
             pydocstyle client_python.py
   release-nightly:
     docker:
-      - image: docker:19
+      - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - run:
           name: Early return if this build is from a forked repository
           command: |
@@ -70,7 +71,6 @@ jobs:
               echo "Nothing to do for forked repositories, so marking this step successful"
               circleci step halt
             fi
-      - checkout
       - run:
           name: Build and push Docker image
           command: |


### PR DESCRIPTION
## Proposed Changes

- use Docker v19.03.13
- use CircleCI image

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
