### PR TITLE
feat(app/server): add node application monitoring

### DIFF
--- a/app/server/index.js
+++ b/app/server/index.js
@@ -5,15 +5,13 @@ const proxy = require('express-http-proxy')
 const apis = require('./apis')
 const onboardInfluxDB = require('./influxdb/onboarding')
 const {logEnvironment, INFLUX_URL} = require('./env')
+const monitor = require('./monitor')
 
 async function startApplication() {
   const app = express()
 
-  // log request URLs
-  app.use((req, _resp, next) => {
-    console.info(`${req.method} ${req.path}`)
-    next()
-  })
+  // monitor application
+  monitor(app)
 
   // APIs
   app.use('/api', apis)

--- a/app/server/monitor.js
+++ b/app/server/monitor.js
@@ -1,0 +1,75 @@
+const {InfluxDB, Point} = require('@influxdata/influxdb-client')
+const {
+  INFLUX_URL: url,
+  INFLUX_TOKEN: token,
+  INFLUX_ORG: org,
+  INFLUX_BUCKET: bucket,
+} = require('./env')
+const responseTime = require('response-time')
+
+// create Influx Write API to report application monitoring data
+const writeAPI = new InfluxDB({url, token}).getWriteApi(org, bucket, 'ns', {
+  defaultTags: {
+    service: 'iot_center',
+    host: require('os').hostname(),
+  },
+})
+// write node resource/cpu/memory usage
+function writeProcessUsage() {
+  function createPoint(measurement, usage) {
+    const point = new Point(measurement)
+    for (const key of Object.keys(usage)) {
+      point.floatField(key, usage[key])
+    }
+    return point
+  }
+
+  // https://nodejs.org/api/process.html#process_process_memoryusage
+  writeAPI.writePoint(createPoint('node_memory_usage', process.memoryUsage()))
+  // https://nodejs.org/api/process.html#process_process_cpuusage_previousvalue
+  writeAPI.writePoint(createPoint('node_cpu_usage', process.cpuUsage()))
+  // https://nodejs.org/api/process.html#process_process_resourceusage
+  writeAPI.writePoint(
+    createPoint('node_resource_usage', process.resourceUsage())
+  )
+}
+// write process usage now and then every 10 seconds
+writeProcessUsage()
+const nodeUsageTimer = setInterval(writeProcessUsage, 10_000).unref()
+
+// on shutdown
+// - clear reporting of node usage
+// - flush unwritten points and cancel retries
+async function onShutdown() {
+  clearInterval(nodeUsageTimer)
+  try {
+    await writeAPI.close()
+  } catch (error) {
+    console.error('ERROR: Application monitoring', error)
+  }
+  // eslint-disable-next-line no-process-exit
+  process.exit(0)
+}
+process.on('SIGINT', onShutdown)
+process.on('SIGTERM', onShutdown)
+
+// export a monitoring function for express.js response time monitoring
+module.exports = function (app) {
+  app.use(
+    responseTime((req, res, time) => {
+      // print out request basics
+      console.info(
+        `${req.method} ${req.path} ${res.statusCode} ${
+          Math.round(time * 100) / 100
+        }ms`
+      )
+      // write response time to InfluxDB
+      const point = new Point('express_http_server')
+        .tag('uri', req.path)
+        .tag('method', req.method)
+        .tag('status', String(res.statusCode))
+        .floatField('response_time', time)
+      writeAPI.writePoint(point)
+    })
+  )
+}

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -6,7 +6,8 @@
     "@influxdata/influxdb-client": "1.7.0-nightly.10",
     "@influxdata/influxdb-client-apis": "^1.6.0",
     "express": "^4.17.1",
-    "express-http-proxy": "^1.6.2"
+    "express-http-proxy": "^1.6.2",
+    "response-time": "^2.3.2"
   },
   "scripts": {
     "start": "node index.js",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4296,7 +4296,7 @@ delegate@^3.1.2:
   resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
   integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
-depd@~1.1.2:
+depd@~1.1.0, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -8462,7 +8462,7 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@~1.0.2:
+on-headers@~1.0.1, on-headers@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
   integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
@@ -10865,6 +10865,14 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.1
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
+
+response-time@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/response-time/-/response-time-2.3.2.tgz#ffa71bab952d62f7c1d49b7434355fbc68dffc5a"
+  integrity sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=
+  dependencies:
+    depd "~1.1.0"
+    on-headers "~1.0.1"
 
 responselike@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR adds monitoring to the iot_center node application. The following measurements are written to a configured InfluxDB.
 * `express_http_server` with every request
   * field: response_time (milliseconds)
   * tags: uri, method, status, host=`os.hostname()`, service=`iot_center`
 * `node_memory_usage` every 10 seconds
   * fields: https://nodejs.org/api/process.html#process_process_memoryusage
   * tags: host=`os.hostname()`, service=`iot_center`
 * `node_cpu_usage` every 10 seconds
   * fields: https://nodejs.org/api/process.html#process_process_cpuusage_previousvalue
   * tags: host=`os.hostname()`, service=`iot_center`
 * `node_resource_usage` every 10 seconds
   * fields: https://nodejs.org/api/process.html#process_process_resourceusage
   * tags: host=`os.hostname()`, service=`iot_center`


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
