### PR TITLE
feat: Add Markdown panel documentation

### DIFF
--- a/app/ui/public/help/DashboardPage.md
+++ b/app/ui/public/help/DashboardPage.md
@@ -1,3 +1,5 @@
-## This is Dashboard Page
+## Dashboard page
 
-[Source Code in Dashboard.tsx](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DashboardPage.tsx)
+[_Source code for this page on GitHub_](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DashboardPage.tsx)
+
+For more, see the [*InfluxDB IoT dev guide*](https://influxdata.github.io/iot-dev-guide/pages/dashboard.html).

--- a/app/ui/public/help/DevicePage.md
+++ b/app/ui/public/help/DevicePage.md
@@ -1,3 +1,3 @@
-## This is Device Page
+## Device page
 
-[Source Code in DevicePage.tsx](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DevicePage.tsx)
+[_Source code for this page on GitHub_](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DevicePage.tsx)

--- a/app/ui/public/help/DevicesPage.md
+++ b/app/ui/public/help/DevicesPage.md
@@ -1,3 +1,5 @@
-## This is Devices Page Help
+## Device Registration page
 
-[Source Code in DevicesPage.tsx](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DevicesPage.tsx)
+[_Source code for this page on GitHub_](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DevicesPage.tsx)
+
+For more, see the [*InfluxDB IoT dev guide*](https://influxdata.github.io/iot-dev-guide/pages/device-registration.html).

--- a/app/ui/public/help/HomePage.md
+++ b/app/ui/public/help/HomePage.md
@@ -1,4 +1,13 @@
-# IoT Center V2 Homepage
-[README.md](https://github.com/bonitoo-io/iot-center-v2/blob/master/README.md)
+# Welcome to IoT Center!
 
+The _IoT Center_ is designed for demonstration purposes.
+For an in depth look, see the [*InfluxDB IoT dev guide*](https://influxdata.github.io/iot-dev-guide).
+
+The _Iot Center_ application manages IoT devices that write data into InfluxDB.
+IoT Center shows connected devices and measured values from InfluxDB in custom dashboards.
+It is designed to demonstrate one possible application architecture for a web app using InfluxDB and IoT clients.
+
+Each IoT device measures temperature.
+Depending on the connected sensors, it can provide additional measurements like humidity, pressure, and CO2 concentration.
+Each device can either provide static GPS coordinates or actual coordinates from a connected GPS module.
 

--- a/app/ui/public/help/VirtualDevicePage.md
+++ b/app/ui/public/help/VirtualDevicePage.md
@@ -1,3 +1,13 @@
-## This is Virtual Device Page
+## Virtual Device page
 
-[Source Code in DevicePage.tsx](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DevicePage.tsx)
+[_Source code for this page on GitHub_](https://github.com/bonitoo-io/iot-center-v2/blob/master/app/ui/src/pages/DevicePage.tsx)
+
+The virtual device emulates a real device, generating examples data so that we can use IoT Center without needing a real device.
+It writes measurements for every minute in the last 30 days.
+It can also generate and send temperature, humidity, pressure, CO2, TVOC, latitude, and longitude measurements.
+
+The “device” is a piece of code that runs in the browser.
+It uses the [influxdb-client-js] library.
+It gets the configuration of how to communicate with InfluxDB (URL, organization, bucket, token) from IoT center.
+
+For more, see the [*InfluxDB IoT dev guide*](https://influxdata.github.io/iot-dev-guide/pages/virtual-device.html).


### PR DESCRIPTION
This is the first pass at adding in-app Markdown documentation based on the [InfluxDB IoT dev guide](https://github.com/influxdata/iot-dev-guide).

Work toward #29.

## Changes

- Add short descriptions to Home and Virtual Device pages.
- Add links to IoT dev guide chapters.
- Edit GitHub source code links.
