### PR TITLE
feat(app): send timestamp in ns because of telegraf

### DIFF
--- a/app/ui/src/pages/DevicePage.tsx
+++ b/app/ui/src/pages/DevicePage.tsx
@@ -148,7 +148,7 @@ async function writeEmulatedData(
     const batchSize = 2000
     const url = kafka_write_enabled ? '/kafka' : '/influx'
     const influxDB = new InfluxDB({url, token})
-    const writeApi = influxDB.getWriteApi(org, bucket, 'ms', {
+    const writeApi = influxDB.getWriteApi(org, bucket, 'ns', {
       batchSize: batchSize + 1,
       defaultTags: {clientId: id},
     })
@@ -173,7 +173,7 @@ async function writeEmulatedData(
           .tag('CO2Sensor', 'virtual_CO2Sensor')
           .tag('TVOCSensor', 'virtual_TVOCSensor')
           .tag('GPSSensor', 'virtual_GPSSensor')
-          .timestamp(lastTime)
+          .timestamp(String(lastTime) + '000000')
         writeApi.writePoint(point)
 
         pointsWritten++


### PR DESCRIPTION
This PR sends virtual device measurements with nanosecond timestamp, so it can be passed as-is t telegraf.

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
