### PR TITLE
feat(app): allow to specify server and development UI ports using env variables

### DIFF
--- a/app/dev.bat
+++ b/app/dev.bat
@@ -12,6 +12,9 @@ SET INFLUX_TOKEN=
 SET INFLUX_ORG=
 REM SET MQTT_TOPIC=iot_center
 REM SET MQTT_URL=mqtt://127.0.0.1:1883
+REM SET SERVER_PORT=5000
+REM SET PORT=3000
+
 
 if [%1]==[mqtt] "C:\Program Files\Mosquitto\mosquitto.exe" -v
 if [%1]==[mqtt] exit

--- a/app/dev.bat
+++ b/app/dev.bat
@@ -15,7 +15,6 @@ REM SET MQTT_URL=mqtt://127.0.0.1:1883
 REM SET SERVER_PORT=5000
 REM SET PORT=3000
 
-
 if [%1]==[mqtt] "C:\Program Files\Mosquitto\mosquitto.exe" -v
 if [%1]==[mqtt] exit
 

--- a/app/dev.sh
+++ b/app/dev.sh
@@ -16,6 +16,8 @@ export INFLUX_TOKEN=
 export INFLUX_ORG=
 # export MQTT_URL=mqtt://127.0.0.1:1883
 # export MQTT_TOPIC=iot_center
+# export SERVER_PORT=5000
+# export PORT=3000
 
 if [ "$1" = "mqtt" ]; then
   if [ "$(uname -s)" = "Darwin" ]; then

--- a/app/run.bat
+++ b/app/run.bat
@@ -9,6 +9,7 @@ SET INFLUX_ORG=<your email>
 
 REM SET MQTT_TOPIC=iot_center
 REM SET MQTT_URL=mqtt://localhost:1883
+REM SET SERVER_PORT=5000
 
 yarn install
 yarn build

--- a/app/run.sh
+++ b/app/run.sh
@@ -10,6 +10,7 @@ export INFLUX_ORG=
 
 # export MQTT_TOPIC=iot_center
 # export MQTT_URL=mqtt://localhost:1883
+# export SERVER_PORT=5000
 
 set -euo pipefail
 yarn install --frozen-lockfile

--- a/app/server/index.js
+++ b/app/server/index.js
@@ -69,7 +69,7 @@ async function startApplication() {
   startProcessMonitoring()
 
   // start HTTP server
-  const port = process.env.PORT || 5000
+  const port = process.env.SERVER_PORT || 5000
   app.listen(port, process.env.HOSTNAME || '0.0.0.0')
 
   logEnvironment()

--- a/app/server/mqtt/subscriber_broker.js
+++ b/app/server/mqtt/subscriber_broker.js
@@ -24,4 +24,5 @@ client.on('connect', function (connection) {
   )
 })
 
-client.connect('ws://localhost:5000/mqtt')
+const port = process.env.SERVER_PORT || 5000
+client.connect(`ws://localhost:${port}/mqtt`)

--- a/app/ui/package.json
+++ b/app/ui/package.json
@@ -35,7 +35,7 @@
     "typescript": "~3.7.2"
   },
   "scripts": {
-    "start": "craco start",
+    "start": "cross-env REACT_APP_SERVER_PORT=$SERVER_PORT craco start",
     "build": "craco build",
     "test": "yarn lint && craco test",
     "lint": "eslint src/**/*.ts{,x}",
@@ -62,6 +62,7 @@
     "@types/react-syntax-highlighter": "^13.5.0",
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
+    "cross-env": "7.0.3",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-jest": "^24.0.1",
     "eslint-plugin-prettier": "^3.1.4",

--- a/app/ui/src/pages/DynamicDashboardPage.tsx
+++ b/app/ui/src/pages/DynamicDashboardPage.tsx
@@ -262,10 +262,9 @@ type RealtimeSubscription = {
   tags: string[]
 }
 
-const host =
-  process.env.NODE_ENV === `development`
-    ? window.location.hostname + ':5000'
-    : window.location.host
+const host = process.env.REACT_APP_SERVER_PORT
+  ? window.location.hostname + ':' + process.env.REACT_APP_SERVER_PORT
+  : window.location.host
 const wsAddress = `ws://${host}/mqtt`
 
 /** length of unix time with milliseconds precision */

--- a/app/ui/src/pages/RealTimePage.tsx
+++ b/app/ui/src/pages/RealTimePage.tsx
@@ -247,10 +247,9 @@ type RealtimeSubscription = {
   tags: string[]
 }
 
-const HOST =
-  process.env.NODE_ENV === `development`
-    ? window.location.hostname + ':5000'
-    : window.location.host
+const HOST = process.env.REACT_APP_SERVER_PORT
+  ? window.location.hostname + ':' + process.env.REACT_APP_SERVER_PORT
+  : window.location.host
 const WS_URL = `ws://${HOST}/mqtt`
 
 /** length of unix time with milliseconds precision */

--- a/app/ui/src/setupProxy.js
+++ b/app/ui/src/setupProxy.js
@@ -1,39 +1,33 @@
 const {createProxyMiddleware} = require('http-proxy-middleware')
+const PORT = process.env.PORT || 5000
 
 module.exports = function (app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      target: 'http://localhost:5000',
+      target: `http://localhost:${PORT}`,
       changeOrigin: true,
     })
   )
   app.use(
     '/influx',
     createProxyMiddleware({
-      target: 'http://localhost:5000',
+      target: `http://localhost:${PORT}`,
       changeOrigin: true,
     })
   )
   app.use(
     '/mqtt',
     createProxyMiddleware({
-      target: 'http://localhost:5000',
+      target: `http://localhost:${PORT}`,
       changeOrigin: true,
     })
   )
   app.use(
     '/kafka',
     createProxyMiddleware({
-      target: 'http://localhost:5000',
+      target: `http://localhost:${PORT}`,
       changeOrigin: true,
     })
   )
-  // app.use(
-  //   '/mqtt',
-  //   createProxyMiddleware({
-  //     target: 'http://localhost:5000',
-  //     ws: true,
-  //   })
-  // )
 }

--- a/app/ui/src/setupProxy.js
+++ b/app/ui/src/setupProxy.js
@@ -1,32 +1,32 @@
 const {createProxyMiddleware} = require('http-proxy-middleware')
-const PORT = process.env.PORT || 5000
+const SERVER_PORT = process.env.SERVER_PORT || 5000
 
 module.exports = function (app) {
   app.use(
     '/api',
     createProxyMiddleware({
-      target: `http://localhost:${PORT}`,
+      target: `http://localhost:${SERVER_PORT}`,
       changeOrigin: true,
     })
   )
   app.use(
     '/influx',
     createProxyMiddleware({
-      target: `http://localhost:${PORT}`,
+      target: `http://localhost:${SERVER_PORT}`,
       changeOrigin: true,
     })
   )
   app.use(
     '/mqtt',
     createProxyMiddleware({
-      target: `http://localhost:${PORT}`,
+      target: `http://localhost:${SERVER_PORT}`,
       changeOrigin: true,
     })
   )
   app.use(
     '/kafka',
     createProxyMiddleware({
-      target: `http://localhost:${PORT}`,
+      target: `http://localhost:${SERVER_PORT}`,
       changeOrigin: true,
     })
   )


### PR DESCRIPTION
Fixes #53

## Proposed Changes
- user can specify `SERVER_PORT` environment variable to change the application port
- user can specify `PORT` variable to change the port of hot-reloading UI ... when in the development mode
  - `PORT` variable is handled OOTB when running react application in development mode
- the main dev and run scripts are changed to include comments with these variables

Nore that the UI web sockets have to directly communicate with the server even in the development mode, because hot reloading does not work properly with proxied web sockets. `yarn start` and the UI code is modified herein to know SERVER_PORT inside the UI (by setting up [REACT_APP_SERVER_PORT](https://create-react-app.dev/docs/adding-custom-environment-variables/) variable)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
