### PR TITLE
feat(app): change device authorization store

### DIFF
--- a/app/server/env.js
+++ b/app/server/env.js
@@ -6,6 +6,8 @@ const INFLUX_TOKEN = process.env.INFLUX_TOKEN || 'my-token'
 const INFLUX_ORG = process.env.INFLUX_ORG || 'my-org'
 /** InfluxDB bucket  */
 const INFLUX_BUCKET = 'iot_center'
+/** InfluxDB bucket that stores registered devices  */
+const INFLUX_BUCKET_DEVICES = 'iot_center_devices'
 
 /** optional Kafka Host */
 const KAFKA_HOST = process.env.KAFKA_HOST
@@ -66,6 +68,7 @@ module.exports = {
   onboarding_password,
   configuration_refresh,
   INFLUX_BUCKET,
+  INFLUX_BUCKET_DEVICES,
   logEnvironment,
   KAFKA_HOST,
   KAFKA_TOPIC,

--- a/app/server/influxdb/authorizations.js
+++ b/app/server/influxdb/authorizations.js
@@ -66,9 +66,6 @@ async function getIoTAuthorization(deviceId) {
 async function createIoTAuthorization(deviceId) {
   const {id: orgID} = await getOrganization()
   const bucketID = await getBucket(INFLUX_BUCKET).id
-  console.log(
-    `createIoTAuthorization: deviceId=${deviceId} orgID=${orgID} bucketID=${bucketID}`
-  )
   return await authorizationsAPI.postAuthorizations({
     body: {
       orgID,
@@ -94,6 +91,15 @@ async function createIoTAuthorization(deviceId) {
  */
 async function deleteAuthorization(key) {
   return authorizationsAPI.deleteAuthorizationsID({authID: key})
+}
+
+/**
+ * Gets authorization using a supplied InfluxDB key
+ * @param {string} key InfluxDB id of the authorization
+ * @return {Promise} promise with authorization, can be en arror
+ */
+async function getAuthorization(key) {
+  return authorizationsAPI.getAuthorizationsID({authID: key})
 }
 
 /**
@@ -130,9 +136,11 @@ function isBucketRWAuthorized(authorization, bucketId) {
 
 module.exports = {
   getAuthorizations,
+  getAuthorization,
   getDeviceId,
   getIoTAuthorizations,
   getIoTAuthorization,
   createIoTAuthorization,
   deleteAuthorization,
+  isBucketRWAuthorized,
 }

--- a/app/server/influxdb/authorizations.js
+++ b/app/server/influxdb/authorizations.js
@@ -6,7 +6,6 @@ const {INFLUX_BUCKET} = require('../env')
 
 const authorizationsAPI = new AuthorizationsAPI(influxdb)
 const DESC_PREFIX = 'IoT Center: '
-const CREATE_BUCKET_SPECIFIC_AUTHORIZATIONS = false
 
 /**
  * Gets all authorizations.
@@ -69,10 +68,7 @@ async function getIoTAuthorization(deviceId) {
  */
 async function createIoTAuthorization(deviceId) {
   const {id: orgID} = await getOrganization()
-  let bucketID = undefined
-  if (CREATE_BUCKET_SPECIFIC_AUTHORIZATIONS) {
-    bucketID = await getBucket(INFLUX_BUCKET).id
-  }
+  const bucketID = await getBucket(INFLUX_BUCKET).id
   console.log(
     `createIoTAuthorization: deviceId=${deviceId} orgID=${orgID} bucketID=${bucketID}`
   )

--- a/app/server/influxdb/authorizations.js
+++ b/app/server/influxdb/authorizations.js
@@ -9,9 +9,8 @@ const DESC_PREFIX = 'IoT Center: '
 
 /**
  * Gets all authorizations.
- * @return promise with an array of authorizations
  * @see https://influxdata.github.io/influxdb-client-js/influxdb-client-apis.authorization.html
- * @return {Array<import('@influxdata/influxdb-client-apis').Authorization>}
+ * @returns {Array<import('@influxdata/influxdb-client-apis').Authorization>} promise with authorizations
  */
 async function getAuthorizations() {
   const {id: orgID} = await getOrganization()
@@ -21,9 +20,8 @@ async function getAuthorizations() {
 
 /**
  * Gets all IoT Center device authorizations.
- * @return promise with an authorization or undefined
  * @see https://influxdata.github.io/influxdb-client-js/influxdb-client-apis.authorization.html
- * @return {Array<import('@influxdata/influxdb-client-apis').Authorization>}
+ * @returns {Array<import('@influxdata/influxdb-client-apis').Authorization>} promise with authorizations
  */
 async function getIoTAuthorizations() {
   const authorizations = await getAuthorizations()
@@ -36,9 +34,8 @@ async function getIoTAuthorizations() {
 }
 /**
  * Gets IoT Center device authorization.
- * @return promise with an authorization or undefined
  * @see https://influxdata.github.io/influxdb-client-js/influxdb-client-apis.authorization.html
- * @return {import('@influxdata/influxdb-client-apis').Authorization} promise with authorization, undefined or an error
+ * @returns {import('@influxdata/influxdb-client-apis').Authorization} promise with an authorization or undefined
  */
 async function getIoTAuthorization(deviceId) {
   const authorizations = await getAuthorizations()
@@ -64,7 +61,7 @@ async function getIoTAuthorization(deviceId) {
 /**
  * Creates authorization for a supplied deviceId
  * @param {string} deviceId client identifier
- * @return {import('@influxdata/influxdb-client-apis').Authorization} promise with authorization or an error
+ * @returns {import('@influxdata/influxdb-client-apis').Authorization} promise with authorization or an error
  */
 async function createIoTAuthorization(deviceId) {
   const {id: orgID} = await getOrganization()
@@ -102,7 +99,7 @@ async function deleteAuthorization(key) {
 /**
  * Gets client ID from authorization object.
  * @param {import('@influxdata/influxdb-client-apis').Authorization} authorization
- * @return client identifier
+ * @returns client identifier
  */
 function getDeviceId(authorization) {
   const description = String(authorization.description)
@@ -116,7 +113,7 @@ function getDeviceId(authorization) {
  * Checks if the supplied authorization allows to read and write INFLUX_BUCKET.
  * @param {import('@influxdata/influxdb-client-apis').Authorization} authorization
  * @param {string} bucketId INFLUX_BUCKET identifier
- * @return {boolean} true if it can
+ * @returns {boolean} true if it can
  */
 function isBucketRWAuthorized(authorization, bucketId) {
   const bucketRW = authorization.permissions.reduce((acc, val) => {

--- a/app/server/influxdb/authorizations.js
+++ b/app/server/influxdb/authorizations.js
@@ -5,7 +5,7 @@ const {getBucket} = require('./buckets')
 const {INFLUX_BUCKET} = require('../env')
 
 const authorizationsAPI = new AuthorizationsAPI(influxdb)
-const DESC_PREFIX = 'IoT Center: '
+const DESC_PREFIX = 'IoTCenterDevice: '
 
 /**
  * Gets all authorizations.

--- a/app/server/influxdb/buckets.js
+++ b/app/server/influxdb/buckets.js
@@ -4,6 +4,9 @@ const {INFLUX_BUCKET} = require('../env')
 const {getOrganization} = require('./organizations')
 const bucketsAPI = new BucketsAPI(influxdb)
 
+// a simple cache that contains buckets
+const bucketsCache = {}
+
 /**
  * Gets details for a bucket supplied by name.
  * @param {string} name bucket name, optional defaults to env.INFLUX_BUCKET
@@ -14,9 +17,16 @@ async function getBucket(name) {
   if (!name) {
     name = INFLUX_BUCKET
   }
+  if (bucketsCache[name]) {
+    return {...bucketsCache[name]}
+  }
   const {id: orgID} = await getOrganization()
   const buckets = await bucketsAPI.getBuckets({name: INFLUX_BUCKET, orgID})
-  return buckets.buckets[0]
+  const retVal = buckets.buckets[0]
+  if (retVal) {
+    bucketsCache[name] = {...retVal}
+  }
+  return retVal
 }
 
 /**

--- a/app/server/influxdb/buckets.js
+++ b/app/server/influxdb/buckets.js
@@ -21,7 +21,7 @@ async function getBucket(name) {
     return {...bucketsCache[name]}
   }
   const {id: orgID} = await getOrganization()
-  const buckets = await bucketsAPI.getBuckets({name: INFLUX_BUCKET, orgID})
+  const buckets = await bucketsAPI.getBuckets({name, orgID})
   const retVal = buckets.buckets[0]
   if (retVal) {
     bucketsCache[name] = {...retVal}
@@ -42,7 +42,7 @@ async function createBucket(name) {
   const {id: orgID} = await getOrganization()
   return await bucketsAPI.postBuckets({
     body: {
-      name: INFLUX_BUCKET,
+      name,
       orgID,
       description: 'Created by IoT Center',
       retentionRules: [],

--- a/app/server/influxdb/devices.js
+++ b/app/server/influxdb/devices.js
@@ -1,0 +1,140 @@
+const {Point, flux, HttpError} = require('@influxdata/influxdb-client')
+const influxdb = require('./influxdb')
+const {
+  deleteAuthorization,
+  createIoTAuthorization,
+} = require('./authorizations')
+const {INFLUX_ORG, INFLUX_BUCKET_DEVICES} = require('../env')
+
+/**
+ * Gets devices or a particular device when deviceId is specified. Tokens
+ * are not returned unless deviceId is specified. It can also return devices
+ * with empty/unknown key, such devices can be ignored (InfluxDB authorization is not associated).
+ * @param deviceId optional deviceId
+ * @returns promise with an Record<deviceId, {deviceId, createdAt, updatedAt, key, token}>.
+ */
+async function getDevices(deviceId) {
+  const queryApi = influxdb.getQueryApi(INFLUX_ORG)
+  const deviceFilter =
+    deviceId !== undefined
+      ? flux` and r.deviceId == "${deviceId}"`
+      : flux` and r._field != "token"`
+  const fluxQuery = flux`from(bucket:${INFLUX_BUCKET_DEVICES}) 
+    |> range(start: 0) 
+    |> filter(fn: (r) => r._measurement == "deviceauth"${deviceFilter})
+    |> last()`
+  const devices = {}
+  console.log('*** QUERY ***')
+  return await new Promise((resolve, reject) => {
+    queryApi.queryRows(fluxQuery, {
+      next(row, tableMeta) {
+        const o = tableMeta.toObject(row)
+        const deviceId = o.deviceId
+        if (!deviceId) {
+          return
+        }
+        const device = devices[deviceId] || (devices[deviceId] = {deviceId})
+        device[o._field] = o._value
+        if (!device.updatedAt || device.updatedAt < o._time) {
+          device.updatedAt = o._time
+        }
+      },
+      error: reject,
+      complete() {
+        resolve(devices)
+      },
+    })
+  })
+}
+
+/**
+ * Creates a new device with associated InfluxDB authorization.
+ * @param {string} deviceId
+ * @returns promise with {deviceId, createdAt, key, token}.
+ */
+async function createDevice(deviceId) {
+  console.log(`createDevice: deviceId=${deviceId}`)
+
+  const writeApi = influxdb.getWriteApi(INFLUX_ORG, INFLUX_BUCKET_DEVICES)
+  const createdAt = new Date().toISOString()
+  const point = new Point('deviceauth')
+    .tag('deviceId', deviceId)
+    .stringField('createdAt', createdAt)
+  writeApi.writePoint(point)
+  await writeApi.close()
+  const {id: key, token} = await createDeviceAuthorization(deviceId)
+  return {deviceId, createdAt, key, token}
+}
+
+/**
+ * Removes authorization from a specified device including
+ * InfluxDB authorization.
+ * @param {string} deviceId
+ * @param {string} key optional key of InfluxDB authorization
+ * @returns true if it was removed
+ */
+async function removeDeviceAuthorization(deviceId, key) {
+  console.log(`removeDeviceAuthorization: deviceId=${deviceId}`)
+  if (!key) {
+    const devices = await getDevices(deviceId)
+    const device = devices[deviceId]
+    if (!device || !device.key) {
+      // device is not available or authorization is already removed
+      return false
+    }
+    key = device.key
+  }
+  // delete authorization object
+  try {
+    await deleteAuthorization(key)
+  } catch (e) {
+    if (!(e instanceof HttpError) || e.statusCode !== 404) {
+      // device authorization does not exist
+      throw e
+    }
+  }
+  // set empty key and token for the device
+  const writeApi = influxdb.getWriteApi(
+    INFLUX_ORG,
+    INFLUX_BUCKET_DEVICES,
+    'ms',
+    {batchSize: 2}
+  )
+  const point = new Point('deviceauth')
+    .tag('deviceId', deviceId)
+    .stringField('key', '')
+    .stringField('token', '')
+  writeApi.writePoint(point)
+  await writeApi.close()
+  return true
+}
+
+/**
+ * Creates and assigns authorization to the specified device.
+ * @param {string} deviceId
+ */
+async function createDeviceAuthorization(deviceId) {
+  console.log(`createDeviceAuthorization: deviceId=${deviceId}`)
+  const authorization = await createIoTAuthorization(deviceId)
+  // set empty key and token for the device
+  const writeApi = influxdb.getWriteApi(
+    INFLUX_ORG,
+    INFLUX_BUCKET_DEVICES,
+    'ms',
+    {batchSize: 2}
+  )
+  const point = new Point('deviceauth')
+    .tag('deviceId', deviceId)
+    .stringField('key', authorization.id)
+    .stringField('token', authorization.token)
+  writeApi.writePoint(point)
+  await writeApi.close()
+  return authorization
+}
+
+module.exports = {
+  getDevices,
+  createDevice,
+  removeDeviceAuthorization,
+  createDeviceAuthorization,
+}


### PR DESCRIPTION
This PR changes the server part of IoT Center application to store device registrations (and device authorization tokens) into 
`deviceauth` measurement of a new `iot_center_devices` bucket. This is required for IoT center to work properly against the newest InfluxDB (cloud including).

## Before this PR
Devices are registered simply by creating an authorization in InfluxDB with a name that matches a specific pattern. The list of devices is then created from all authorizations that match the pattern. The device name is always deducted from the authorization name. Each particular device has own authorization token, that is stored in the authorization object. THE ISSUE is that the newest InfluxDB does not return an authorization token when receiving authorization(s), the token is redacted. IoT center then passes wrong authorization tokens to all devices (including a virtual one).

## Proposed Changes
- IoT center creates a new bucket named `iot_center_devices` upon startup
- Device registrations are stored in `deviceauth` measurement in a new `iot_center_devices` bucket
  - the data are always stored with `deviceId` tag 
  - create operation simply create an InfluxDB authorization for the device and adds data to `deviceauth` measurement (including authorization id and authorization token is stored)
    - the created token grants RW only to `iot_center` bucket, the devices thus cannot list authorization tokens of other devices
  - delete operation removes InfluxDB authorization and adds data that mark device registration invalid (authorization id is empty)
  - list operation takes `last()` values in the returned tables, the latest change in the device registration(s) is thus simply returned

## Checklist

- [x] Rebased/mergeable
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
