### PR TITLE
fix(app/ui): generate unique react row key

### DIFF
--- a/app/ui/src/pages/DevicePage.tsx
+++ b/app/ui/src/pages/DevicePage.tsx
@@ -247,6 +247,8 @@ async function writeEmulatedData(
   return pointsWritten
 }
 
+const measurementTableRowKey = (r: any) => r._field
+
 interface PropsRoute {
   deviceId?: string
 }
@@ -483,6 +485,7 @@ const DevicePage: FunctionComponent<
         dataSource={deviceData?.measurements}
         columns={columnDefinitions}
         pagination={false}
+        rowKey={measurementTableRowKey}
       />
       <div style={{height: 20}} />
       {isVirtualDevice && mqttEnabled ? (

--- a/app/ui/src/pages/DevicesPage.tsx
+++ b/app/ui/src/pages/DevicesPage.tsx
@@ -91,6 +91,8 @@ interface Props {
   helpCollapsed: boolean
 }
 
+const deviceTableRowKey = (r: any) => r.deviceId
+
 const DevicesPage: FunctionComponent<Props> = ({helpCollapsed}) => {
   const [loading, setLoading] = useState(true)
   const [message, setMessage] = useState<Message | undefined>(undefined)
@@ -298,7 +300,11 @@ const DevicesPage: FunctionComponent<Props> = ({helpCollapsed}) => {
         </>
       }
     >
-      <Table dataSource={data} columns={columnDefinitions}></Table>
+      <Table
+        dataSource={data}
+        columns={columnDefinitions}
+        rowKey={deviceTableRowKey}
+      />
     </PageContent>
   )
 }


### PR DESCRIPTION
This PR fixes the following warnings that appear in the console, it does so by setting up a unique key in ANTD tables.

```
index.js:1 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `Body`. See https://reactjs.org/link/warning-keys for more information.
    at BodyRow (http://localhost:3000/static/js/1.chunk.js:356557:25)
    at Body (http://localhost:3000/static/js/1.chunk.js:356943:19)
    at table
    at div
    at div
    at http://localhost:3000/static/js/1.chunk.js:358064:23
    at div
    at Table (http://localhost:3000/static/js/1.chunk.js:358079:25)
    at div
    at div
    at Spin (http://localhost:3000/static/js/1.chunk.js:238641:37)
    at div
    at InternalTable (http://localhost:3000/static/js/1.chunk.js:239061:34)
    at div
    at div
    at Spin (http://localhost:3000/static/js/1.chunk.js:219529:94)
    at div
    at main
    at Basic (http://localhost:3000/static/js/1.chunk.js:212381:25)
    at Adapter (http://localhost:3000/static/js/1.chunk.js:212364:79)
    at PageContent (http://localhost:3000/static/js/main.chunk.js:3988:24)
    at DevicePage (http://localhost:3000/static/js/main.chunk.js:1977:5)
    at Route (http://localhost:3000/static/js/1.chunk.js:418744:29)
    at Switch (http://localhost:3000/static/js/1.chunk.js:418946:29)
    at section
    at BasicLayout (http://localhost:3000/static/js/1.chunk.js:212396:76)
    at Adapter (http://localhost:3000/static/js/1.chunk.js:212364:79)
    at div
    at App (http://localhost:3000/static/js/main.chunk.js:511:45)
    at C (http://localhost:3000/static/js/1.chunk.js:419001:37)
    at Router (http://localhost:3000/static/js/1.chunk.js:418375:30)
    at BrowserRouter (http://localhost:3000/static/js/1.chunk.js:417996:35)
```


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
