### PR TITLE
fix: increase test timeout for docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
             docker run \
               --rm \
               --link iot-center \
-              inutano/wget:1.20.3-r1 wget -S --spider --tries=10 --retry-connrefused --waitretry=5 http://iot-center:5000/
+              inutano/wget:1.20.3-r1 wget -S --spider --tries=25 --retry-connrefused --waitretry=5 http://iot-center:5000/
       - run:
           name: Print Docker output logs
           command: docker logs iot-center


### PR DESCRIPTION
This PR increases the timeout that is required for iot-center docker to start, it can actually take more than 120 seconds. It will drop with #58 , still the increased timeout can remain.

- [x] Rebased/mergeable
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
