### PR TITLE
fix(ci): print iot-center docker logs on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,6 @@ jobs:
             docker run \
               --name iot-center \
               --detach \
-              --rm \
               --link influxdb_v2 \
               --env INFLUX_URL=http://influxdb_v2:8086 \
               --env INFLUX_TOKEN=my-token \
@@ -112,6 +111,9 @@ jobs:
               --rm \
               --link iot-center \
               inutano/wget:1.20.3-r1 wget -S --spider --tries=25 --retry-connrefused --waitretry=5 http://iot-center:5000/
+      - run:
+          name: Stop iot-center docker
+          command: docker stop iot-center || true
       - run:
           name: Print Docker output logs
           command: docker logs iot-center

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,15 @@ jobs:
               --link iot-center \
               inutano/wget:1.20.3-r1 wget -S --spider --tries=25 --retry-connrefused --waitretry=5 http://iot-center:5000/
       - run:
-          name: Stop iot-center docker
+          name: Stop iot-center container
           command: docker stop iot-center || true
       - run:
           name: Print Docker output logs
           command: docker logs iot-center
           when: on_fail
+      - run:
+          name: Remove iot-center container
+          command: docker rm iot-center || true
       - run:
           name: Save Docker image Cache
           command: |


### PR DESCRIPTION
This PR makes sure that the iot-center docker container is not deleted before printing its logs.

- [x] Rebased/mergeable
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
