### PR TITLE
fix(app/server): run fs.watch with a created folder

### DIFF
--- a/app/server/dynamic/index.js
+++ b/app/server/dynamic/index.js
@@ -46,6 +46,9 @@ const createDir = (logLabel, path, callback) => {
       })
   })
 }
+
+// implement simple caching to avoid frequest fs access
+let FILE_CACHE = {}
 createDir('data', DIR_USER_DATA, () => {
   createDir('dynamic', DIR_DYNAMIC_DASHBOARDS, () => {
     fs.copyFile(
@@ -69,12 +72,10 @@ createDir('data', DIR_USER_DATA, () => {
         if (e) console.error(e)
       }
     )
+    // watch for file changes to invalidate cache
+    fs.watch(DIR_DYNAMIC_DASHBOARDS, {}, () => (FILE_CACHE = {}))
   })
 })
-
-// implement simple caching to avoid frequest fs access
-let FILE_CACHE = {}
-fs.watch(DIR_DYNAMIC_DASHBOARDS, {}, () => (FILE_CACHE = {}))
 
 function listFiles(callback) {
   if (FILE_CACHE.listFiles) {


### PR DESCRIPTION
This PR fixes the following start-time error when app/server is started:
```
node:internal/fs/watchers:252
    throw error;
    ^

Error: ENOENT: no such file or directory, watch '/usr/src/data/dynamic'
    at FSWatcher.<computed> (node:internal/fs/watchers:244:19)
    at Object.watch (node:fs:2249:34)
    at Object.<anonymous> (/usr/src/app/server/dynamic/index.js:77:4)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1155:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/src/app/server/apis/index.js:10:23) {
  errno: -2,
  syscall: 'watch',
  code: 'ENOENT',
  path: '/usr/src/data/dynamic',
  filename: '/usr/src/data/dynamic'
}
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
