### PR TITLE
fix(app): use one bucket for device reporting and device authentication store OOTB

### DIFF
--- a/app/dev.bat
+++ b/app/dev.bat
@@ -10,8 +10,10 @@ REM   typically your email (can be changed)
 SET INFLUX_URL=
 SET INFLUX_TOKEN=
 SET INFLUX_ORG=
+
 REM SET INFLUX_BUCKET=iot_center
 REM SET INFLUX_BUCKET_AUTH=iot_center_devices
+
 REM SET MQTT_TOPIC=iot_center
 REM SET MQTT_URL=mqtt://127.0.0.1:1883
 REM SET SERVER_PORT=5000

--- a/app/dev.bat
+++ b/app/dev.bat
@@ -10,6 +10,8 @@ REM   typically your email (can be changed)
 SET INFLUX_URL=
 SET INFLUX_TOKEN=
 SET INFLUX_ORG=
+REM SET INFLUX_BUCKET=iot_center
+REM SET INFLUX_BUCKET_AUTH=iot_center_devices
 REM SET MQTT_TOPIC=iot_center
 REM SET MQTT_URL=mqtt://127.0.0.1:1883
 REM SET SERVER_PORT=5000

--- a/app/dev.sh
+++ b/app/dev.sh
@@ -14,6 +14,10 @@
 export INFLUX_URL=
 export INFLUX_TOKEN=
 export INFLUX_ORG=
+
+# export INFLUX_BUCKET=iot_center
+# export INFLUX_BUCKET_AUTH=iot_center_devices
+
 # export MQTT_URL=mqtt://127.0.0.1:1883
 # export MQTT_TOPIC=iot_center
 # export SERVER_PORT=5000

--- a/app/run.bat
+++ b/app/run.bat
@@ -7,6 +7,9 @@ SET INFLUX_TOKEN=<generated token in the InfluxDB UI>
 REM SET INFLUX_ORG=iotCenter@influxdata.com
 SET INFLUX_ORG=<your email>
 
+REM SET INFLUX_BUCKET=iot_center
+REM SET INFLUX_BUCKET_AUTH=iot_center_devices
+
 REM SET MQTT_TOPIC=iot_center
 REM SET MQTT_URL=mqtt://localhost:1883
 REM SET SERVER_PORT=5000

--- a/app/run.sh
+++ b/app/run.sh
@@ -8,6 +8,9 @@ export INFLUX_URL=
 export INFLUX_TOKEN=
 export INFLUX_ORG=
 
+# export INFLUX_BUCKET=iot_center
+# export INFLUX_BUCKET_AUTH=iot_center_devices
+
 # export MQTT_TOPIC=iot_center
 # export MQTT_URL=mqtt://localhost:1883
 # export SERVER_PORT=5000

--- a/app/server/env.js
+++ b/app/server/env.js
@@ -7,7 +7,7 @@ const INFLUX_ORG = process.env.INFLUX_ORG || 'my-org'
 /** InfluxDB bucket  */
 const INFLUX_BUCKET = process.env.INFLUX_BUCKET || 'iot_center'
 /** InfluxDB bucket that stores registered devices  */
-const INFLUX_BUCKET_DEVICES = process.env.INFLUX_BUCKET_DEVICES || 'iot_center'
+const INFLUX_BUCKET_AUTH = process.env.INFLUX_BUCKET_AUTH || 'iot_center'
 
 /** optional Kafka Host */
 const KAFKA_HOST = process.env.KAFKA_HOST
@@ -40,7 +40,7 @@ function logEnvironment() {
   console.log(`INFLUX_TOKEN=${INFLUX_TOKEN ? '***' : ''}`)
   console.log(`INFLUX_ORG=${INFLUX_ORG}`)
   console.log(`INFLUX_BUCKET=${INFLUX_BUCKET}`)
-  console.log(`INFLUX_BUCKET_DEVICES=${INFLUX_BUCKET_DEVICES}`)
+  console.log(`INFLUX_BUCKET_AUTH=${INFLUX_BUCKET_AUTH}`)
   if (KAFKA_HOST) {
     console.log(`KAFKA_HOST=${KAFKA_HOST}`)
   }
@@ -69,7 +69,7 @@ module.exports = {
   onboarding_password,
   configuration_refresh,
   INFLUX_BUCKET,
-  INFLUX_BUCKET_DEVICES,
+  INFLUX_BUCKET_AUTH,
   logEnvironment,
   KAFKA_HOST,
   KAFKA_TOPIC,

--- a/app/server/env.js
+++ b/app/server/env.js
@@ -5,9 +5,9 @@ const INFLUX_TOKEN = process.env.INFLUX_TOKEN || 'my-token'
 /** Organization within InfluxDB  */
 const INFLUX_ORG = process.env.INFLUX_ORG || 'my-org'
 /** InfluxDB bucket  */
-const INFLUX_BUCKET = 'iot_center'
+const INFLUX_BUCKET = process.env.INFLUX_BUCKET || 'iot_center'
 /** InfluxDB bucket that stores registered devices  */
-const INFLUX_BUCKET_DEVICES = 'iot_center_devices'
+const INFLUX_BUCKET_DEVICES = process.env.INFLUX_BUCKET_DEVICES || 'iot_center'
 
 /** optional Kafka Host */
 const KAFKA_HOST = process.env.KAFKA_HOST
@@ -40,6 +40,7 @@ function logEnvironment() {
   console.log(`INFLUX_TOKEN=${INFLUX_TOKEN ? '***' : ''}`)
   console.log(`INFLUX_ORG=${INFLUX_ORG}`)
   console.log(`INFLUX_BUCKET=${INFLUX_BUCKET}`)
+  console.log(`INFLUX_BUCKET_DEVICES=${INFLUX_BUCKET_DEVICES}`)
   if (KAFKA_HOST) {
     console.log(`KAFKA_HOST=${KAFKA_HOST}`)
   }

--- a/app/server/influxdb/devices.js
+++ b/app/server/influxdb/devices.js
@@ -4,7 +4,7 @@ const {
   deleteAuthorization,
   createIoTAuthorization,
 } = require('./authorizations')
-const {INFLUX_ORG, INFLUX_BUCKET_DEVICES} = require('../env')
+const {INFLUX_ORG, INFLUX_BUCKET_AUTH} = require('../env')
 
 /**
  * Gets devices or a particular device when deviceId is specified. Tokens
@@ -19,7 +19,7 @@ async function getDevices(deviceId) {
     deviceId !== undefined
       ? flux` and r.deviceId == "${deviceId}"`
       : flux` and r._field != "token"`
-  const fluxQuery = flux`from(bucket:${INFLUX_BUCKET_DEVICES}) 
+  const fluxQuery = flux`from(bucket:${INFLUX_BUCKET_AUTH}) 
     |> range(start: 0) 
     |> filter(fn: (r) => r._measurement == "deviceauth"${deviceFilter})
     |> last()`
@@ -55,7 +55,7 @@ async function getDevices(deviceId) {
 async function createDevice(deviceId) {
   console.log(`createDevice: deviceId=${deviceId}`)
 
-  const writeApi = influxdb.getWriteApi(INFLUX_ORG, INFLUX_BUCKET_DEVICES)
+  const writeApi = influxdb.getWriteApi(INFLUX_ORG, INFLUX_BUCKET_AUTH)
   const createdAt = new Date().toISOString()
   const point = new Point('deviceauth')
     .tag('deviceId', deviceId)
@@ -94,12 +94,9 @@ async function removeDeviceAuthorization(deviceId, key) {
     }
   }
   // set empty key and token for the device
-  const writeApi = influxdb.getWriteApi(
-    INFLUX_ORG,
-    INFLUX_BUCKET_DEVICES,
-    'ms',
-    {batchSize: 2}
-  )
+  const writeApi = influxdb.getWriteApi(INFLUX_ORG, INFLUX_BUCKET_AUTH, 'ms', {
+    batchSize: 2,
+  })
   const point = new Point('deviceauth')
     .tag('deviceId', deviceId)
     .stringField('key', '')
@@ -117,12 +114,9 @@ async function createDeviceAuthorization(deviceId) {
   console.log(`createDeviceAuthorization: deviceId=${deviceId}`)
   const authorization = await createIoTAuthorization(deviceId)
   // set empty key and token for the device
-  const writeApi = influxdb.getWriteApi(
-    INFLUX_ORG,
-    INFLUX_BUCKET_DEVICES,
-    'ms',
-    {batchSize: 2}
-  )
+  const writeApi = influxdb.getWriteApi(INFLUX_ORG, INFLUX_BUCKET_AUTH, 'ms', {
+    batchSize: 2,
+  })
   const point = new Point('deviceauth')
     .tag('deviceId', deviceId)
     .stringField('key', authorization.id)

--- a/app/server/influxdb/onboarding.js
+++ b/app/server/influxdb/onboarding.js
@@ -54,6 +54,17 @@ async function onboardInfluxDB() {
       }
     }
     await initializeBucket(INFLUX_BUCKET)
+    if (INFLUX_BUCKET_DEVICES === INFLUX_BUCKET) {
+      console.warn(
+        'WARN: INFLUX_BUCKET is the same as INFLUX_BUCKET_DEVICES. Each device can now'
+      )
+      console.warn(
+        '      read authentication tokens of other devices. Setup different '
+      )
+      console.warn(
+        '      INFLUX_BUCKET and INFLUX_BUCKET_DEVICES environment variables.'
+      )
+    }
     await initializeBucket(INFLUX_BUCKET_DEVICES)
   } catch (error) {
     console.error(

--- a/app/server/influxdb/onboarding.js
+++ b/app/server/influxdb/onboarding.js
@@ -7,7 +7,7 @@ const {
   onboarding_username,
   onboarding_password,
   INFLUX_BUCKET,
-  INFLUX_BUCKET_DEVICES,
+  INFLUX_BUCKET_AUTH,
 } = require('../env')
 const {getBucket, createBucket} = require('./buckets')
 
@@ -54,18 +54,19 @@ async function onboardInfluxDB() {
       }
     }
     await initializeBucket(INFLUX_BUCKET)
-    if (INFLUX_BUCKET_DEVICES === INFLUX_BUCKET) {
+    if (INFLUX_BUCKET_AUTH === INFLUX_BUCKET) {
       console.warn(
-        'WARN: INFLUX_BUCKET is the same as INFLUX_BUCKET_DEVICES. Each device can now'
+        'WARN: INFLUX_BUCKET is the same as INFLUX_BUCKET_AUTH. Each device can now'
       )
       console.warn(
         '      read authentication tokens of other devices. Setup different '
       )
       console.warn(
-        '      INFLUX_BUCKET and INFLUX_BUCKET_DEVICES environment variables.'
+        '      INFLUX_BUCKET and INFLUX_BUCKET_AUTH environment variables.'
       )
+    } else {
+      await initializeBucket(INFLUX_BUCKET_AUTH)
     }
-    await initializeBucket(INFLUX_BUCKET_DEVICES)
   } catch (error) {
     console.error(
       `Unable to determine whether InfluxDB at ${INFLUX_URL} is onboarded.`,

--- a/app/server/monitor.js
+++ b/app/server/monitor.js
@@ -3,7 +3,7 @@ const {
   INFLUX_URL: url,
   INFLUX_TOKEN: token,
   INFLUX_ORG: org,
-  INFLUX_BUCKET: bucket,
+  INFLUX_BUCKET_AUTH: bucket,
 } = require('./env')
 const responseTime = require('response-time')
 


### PR DESCRIPTION
This PR changes the defaults so that one bucket `iot_center` is by default used to collect device data and also store authentication tokens for each device. This is required for every free cloud account that allows at most 2 buckets, one of them is created OOTB and at most one can be then created by IoT center. IoT center buckets are now configurable using `INFLUX_BUCKET` and `INFLUX_BUCKET_AUTH` environment variables, both variables are printed on startup. If they are the same, a warning message is printed. The default startup messaging of IoT center now looks like:
```
yarn run v1.22.17
$ node index.js
 _      _______    _______                                            ______  
| |    (_______)  (_______)                _                         (_____ \ 
| |  ___   _       _        _____  ____  _| |_  _____   ____    _   _  ____) )
| | / _ \ | |     | |      | ___ ||  _ \(_   _)| ___ | / ___)  | | | |/ ____/ 
| || |_| || |     | |_____ | ____|| | | | | |_ | ____|| |       \ V /| (_____ 
|_| \___/ |_|      \______)|_____)|_| |_|  \__)|_____)|_|        \_/ |_______)

Enable proxy from /influx/* to http://localhost:8086/*
data directory already exists at:  /home/zavora/devel/influx/bonitoo/iot-center-v2/data
dynamic directory already exists at:  /home/zavora/devel/influx/bonitoo/iot-center-v2/data/dynamic
Bucket 'iot_center' exists.
WARN: INFLUX_BUCKET is the same as INFLUX_BUCKET_AUTH. Each device can now
      read authentication tokens of other devices. Setup different 
      INFLUX_BUCKET and INFLUX_BUCKET_AUTH environment variables.
INFLUX_URL=http://localhost:8086
INFLUX_TOKEN=***
INFLUX_ORG=my-org
INFLUX_BUCKET=iot_center
INFLUX_BUCKET_AUTH=iot_center
Listening on http://localhost:5000
```

## Proposed Changes

_Briefly describe your proposed changes:_

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests run successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
